### PR TITLE
Fix scss matome#show view

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,27 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+
+$(function() {
+    var count = 100;
+ $('.text_overflow').each(function() {
+     var thisText = $(this).text();
+      var textLength = thisText.length;
+       if (textLength > count) {
+            var showText = thisText.substring(0, count);
+            var hideText = thisText.substring(count, textLength);
+           var insertText = showText;
+          insertText += '<span class="hide">' + hideText + '</span>';
+           insertText += '<span class="omit">…</span>';
+            insertText += '<a href="" class="more">もっと見る</a>';
+            $(this).html(insertText);
+       };
+  });
+ $('.text_overflow .hide').hide();
+ $('.text_overflow .more').click(function() {
+      $(this).hide()
+          .prev('.omit').hide()
+         .prev('.hide').fadeIn();
+      return false;
+   });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,10 @@
 //= require turbolinks
 //= require_tree .
 
-$(function() {
+
+//もっと見る機能
+//https://www.tam-tam.co.jp/tipsnote/javascript/post4191.html
+$(document).on('turbolinks:load',function(){
     var count = 100;
  $('.text_overflow').each(function() {
      var thisText = $(this).text();

--- a/app/assets/javascripts/matomes.js
+++ b/app/assets/javascripts/matomes.js
@@ -1,0 +1,25 @@
+// うまく読み込まれていない
+$(function() {
+  alert("aaa");
+    var count = 20;
+ $('.text_overflow').each(function() {
+     var thisText = $(this).text();
+      var textLength = thisText.length;
+       if (textLength > count) {
+            var showText = thisText.substring(0, count);
+            var hideText = thisText.substring(count, textLength);
+           var insertText = showText;
+          insertText += '<span class="hide">' + hideText + '</span>';
+           insertText += '<span class="omit">…</span>';
+            insertText += '<a href="" class="more">もっと見る</a>';
+            $(this).html(insertText);
+       };
+  });
+ $('.text_overflow .hide').hide();
+ $('.text_overflow .more').click(function() {
+      $(this).hide()
+          .prev('.omit').hide()
+         .prev('.hide').fadeIn();
+      return false;
+   });
+});

--- a/app/assets/stylesheets/matomes.scss
+++ b/app/assets/stylesheets/matomes.scss
@@ -20,6 +20,13 @@
   z-index:999;
 }
 
+.novel-title-link{
+  color: blue !important;
+}
+a:hover{
+  background-color: white !important;
+}
+
 .card{
   border-radius: 0px !important;
 }

--- a/app/assets/stylesheets/matomes.scss
+++ b/app/assets/stylesheets/matomes.scss
@@ -19,3 +19,7 @@
   right:15px;
   z-index:999;
 }
+
+.card{
+  border-radius: 0px !important;
+}

--- a/app/views/matomes/_novel-card.html.haml
+++ b/app/views/matomes/_novel-card.html.haml
@@ -1,11 +1,16 @@
-.row
-  .card.mx-2.w-100.shadow
-    .card-title
-      = simple_format(novel.title,:style => "font-size:20px; line-height:160%;")
-      = simple_format(novel.discription,:style => "font-size:17px; line-height:160%;")
-      = simple_format(novel.review,:style => "font-size:20px; line-height:160%;")
-    .card-body.pl-2.pt-3.pb-2{:style => "min-height:100px;"}
-      .row.pl-3.pb-2.small.text-muted
-        = novel.created_at.strftime("%Y/%m/%d/ %H:%M:%S")
-      .font-weight-bold.pb-4
-        = simple_format(novel.discription,:style => "font-size:17px; line-height:160%;")
+%hr
+.fa.fa-commenting-o.fa-2x.ml-2
+おすすめポイント
+= simple_format(novel.review,style: "font-size:18px; line-height:160%;", class: "font-weight-bold px-3 pt-1 pb-3")
+.card{:style => "background-color: #f9f9f9;"}
+  .card-title.p-2.mb-0{:style => "margin-bottom: 0px; font-size:17px; line-height:160%; color: blue;"}
+    = novel.title
+    .fa.fa-external-link
+    -# = simple_format(novel.titleeee,style: "margin-bottom: 0px; font-size:18px; line-height:160%; color: blue;")
+  .card-body.pl-2.pt-0.pb-2{:style => "min-height:100px;"}
+    .text_overflow
+      = simple_format(novel.discription,:style => "font-size:14px; line-height:160%;")
+    -# .row.pl-3.pb-2.small.text-muted
+    -#   = novel.created_at.strftime("%Y/%m/%d/ %H:%M:%S")
+    -# .font-weight-bold.pb-4
+    -#   = simple_format(novel.discription,:style => "font-size:17px; line-height:160%;")

--- a/app/views/matomes/_novel-card.html.haml
+++ b/app/views/matomes/_novel-card.html.haml
@@ -3,14 +3,12 @@
 おすすめポイント
 = simple_format(novel.review,style: "font-size:18px; line-height:160%;", class: "font-weight-bold px-3 pt-1 pb-3")
 .card{:style => "background-color: #f9f9f9;"}
-  .card-title.p-2.mb-0{:style => "margin-bottom: 0px; font-size:17px; line-height:160%; color: blue;"}
-    = novel.title
-    .fa.fa-external-link
-    -# = simple_format(novel.titleeee,style: "margin-bottom: 0px; font-size:18px; line-height:160%; color: blue;")
+  .card-title.p-2.mb-0{:style => "margin-bottom: 0px; font-size:17px; line-height:160%; color: blue !important;"}
+    //TODO urlを持って入ればリンク、持っていなかったらリンクにしないように分ける
+    = link_to novel.url, target: "_blank" do
+      .novel-title-link
+        #{novel.title}
+        .fa.fa-external-link
   .card-body.pl-2.pt-0.pb-2{:style => "min-height:100px;"}
     .text_overflow
       = simple_format(novel.discription,:style => "font-size:14px; line-height:160%;")
-    -# .row.pl-3.pb-2.small.text-muted
-    -#   = novel.created_at.strftime("%Y/%m/%d/ %H:%M:%S")
-    -# .font-weight-bold.pb-4
-    -#   = simple_format(novel.discription,:style => "font-size:17px; line-height:160%;")

--- a/app/views/matomes/index.html.haml
+++ b/app/views/matomes/index.html.haml
@@ -11,13 +11,12 @@
         -# %hr.m-1
         .card-body.p-0{style: "color: #666;" }
           = matome.discription
-          .row
-            .small.text-muted.p-1.pt-2.pl-5{:style => "font-size:11px"}
-              %span{"class"=>"comment-count"}
-              .fa.fa-comments-o
-              -# %span{"class"=>"comment-count"}（#{matome.comments.count}）】
-              = matome.created_at.strftime("%Y/%m/%d/ %H:%M")
-              【#{matome.impressionist_count} PV】
+          .container
+            .row
+              .small.text-muted.p-1.pt-2.pl-5{:style => "font-size:11px"}
+                %span{"class"=>"comment-count"}
+                = matome.created_at.strftime("%Y/%m/%d/ %H:%M")
+                【#{matome.impressionist_count} PV】
 
 %br
 

--- a/app/views/matomes/show.html.haml
+++ b/app/views/matomes/show.html.haml
@@ -11,6 +11,18 @@
     .card-body
       -# .fa.fa-user-o.fa-2x.mr-1
       = @matome.discription
+-# %p
+-#   %b Title:
+-#   = @matome.title
+-# %p
+-#   %b Discription:
+-#   = @matome.discription
+-# %p
+-#   %b Like:
+-#   = @matome.like
+-# %p
+-#   %b User:
+-#   = @matome.user
 
 #novel-cards
   - @novels.each do |novel|
@@ -52,6 +64,7 @@
     .modal-dialog.modal-dialog-centered{:role => "document"}
       .modal-content
         .modal-header
+          -# #exampleModalLabel.modal-title #{@topic.content}
           %button.close{"aria-label" => "閉じる", "data-dismiss" => "modal", :type => "button"}
             .pt-3{"aria-hidden" => "true"} ×
         .modal-body

--- a/app/views/matomes/show.html.haml
+++ b/app/views/matomes/show.html.haml
@@ -1,17 +1,28 @@
-%p#notice= notice
-
-%p
-  %b Title:
-  = @matome.title
-%p
-  %b Discription:
-  = @matome.discription
-%p
-  %b Like:
-  = @matome.like
-%p
-  %b User:
-  = @matome.user
+.container.m-0.p-0
+  %h2.text-center なろうまとめ
+  %p#notice= notice
+  .card{:style => "background-color: #EEEEEE;"}
+    .card-title.m-0
+      お気に入り10件
+    .card-body.p-2
+      .font-weight-bold{:style => "font-size: 22px;"}
+        = @matome.title
+  .card.mb-1{:style => "background-color: #F5F5F5;"}
+    .card-body
+      -# .fa.fa-user-o.fa-2x.mr-1
+      = @matome.discription
+-# %p
+-#   %b Title:
+-#   = @matome.title
+-# %p
+-#   %b Discription:
+-#   = @matome.discription
+-# %p
+-#   %b Like:
+-#   = @matome.like
+-# %p
+-#   %b User:
+-#   = @matome.user
 
 #novel-cards
   - @novels.each do |novel|
@@ -27,16 +38,17 @@
 -# matome_id: nil,
 -# created_at: nil,
 -# updated_at: nil
-.row
-  .mx-auto.mt-4
-    = form_for @novel , :remote => true do |f|
-      = f.label :名前
-      =f.hidden_field :matome_id, :value => @matome.id
-      = f.text_field :title, placeholder:"小説名", required: "required"
-      = f.text_area :discription, :placeholder=>'詳細説明', class: "mt-2 d-block under-comment-text", required: "required"
-      = f.text_area :review, :placeholder=>'レビュー', class: "mt-2 d-block under-comment-text", required: "required"
-      .m-3
-        = f.submit "小説を追加する", class: "btn btn-primary px-5 mx-auto d-block", data: { disable_with: "小説を追加する"}
+.container
+  .row
+    .mx-auto.mt-4
+      = form_for @novel , :remote => true do |f|
+        = f.label :名前
+        =f.hidden_field :matome_id, :value => @matome.id
+        = f.text_field :title, placeholder:"小説名", required: "required"
+        = f.text_area :discription, :placeholder=>'詳細説明', class: "mt-2 d-block under-comment-text", required: "required"
+        = f.text_area :review, :placeholder=>'レビュー', class: "mt-2 d-block under-comment-text", required: "required"
+        .mx-auto
+          = f.submit "小説を追加する", class: "btn btn-primary px-5 mx-auto d-block", data: { disable_with: "小説を追加する"}
 
 = link_to 'Edit', edit_matome_path(@matome)
 \|

--- a/app/views/matomes/show.html.haml
+++ b/app/views/matomes/show.html.haml
@@ -11,18 +11,6 @@
     .card-body
       -# .fa.fa-user-o.fa-2x.mr-1
       = @matome.discription
--# %p
--#   %b Title:
--#   = @matome.title
--# %p
--#   %b Discription:
--#   = @matome.discription
--# %p
--#   %b Like:
--#   = @matome.like
--# %p
--#   %b User:
--#   = @matome.user
 
 #novel-cards
   - @novels.each do |novel|
@@ -64,7 +52,6 @@
     .modal-dialog.modal-dialog-centered{:role => "document"}
       .modal-content
         .modal-header
-          -# #exampleModalLabel.modal-title #{@topic.content}
           %button.close{"aria-label" => "閉じる", "data-dismiss" => "modal", :type => "button"}
             .pt-3{"aria-hidden" => "true"} ×
         .modal-body

--- a/app/views/matomes/show.html.haml
+++ b/app/views/matomes/show.html.haml
@@ -30,11 +30,11 @@
   .row
     .mx-auto.mt-4
       = form_for @novel , :remote => true do |f|
-        = f.label :名前
-        =f.hidden_field :matome_id, :value => @matome.id
+        = f.hidden_field :matome_id, :value => @matome.id
         = f.text_field :title, placeholder:"小説名", required: "required"
         = f.text_area :discription, :placeholder=>'詳細説明', class: "mt-2 d-block under-comment-text", required: "required"
         = f.text_area :review, :placeholder=>'レビュー', class: "mt-2 d-block under-comment-text", required: "required"
+        = f.text_area :url, :placeholder=>'小説URL', class: "mt-2 d-block under-comment-text", required: "required"
         .mx-auto
           = f.submit "小説を追加する", class: "btn btn-primary px-5 mx-auto d-block", data: { disable_with: "小説を追加する"}
 


### PR DESCRIPTION
・小説カードのレイアウトを綺麗にした
・小説カードのタイトルを青くして新しいタブでnovel.urlを開くように設定
・小説の詳細情報にもっと見る機能を追加（https://www.tamtam.co.jp/tipsnote/javascript/post4191.html）


・matomes#indes, showをiphoneでみたときの右端の変な余白を修正
（bootstrapでcontainerクラスに囲まれていないrowがいた）
・jqueryが最初に読み込まれない問題を修正
$(function() {    >>    $(document).on('turbolinks:load',function(){