### PR TITLE
Fix get nove info add allcount

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,7 +32,7 @@ $(document).on('turbolinks:load',function(){
            var insertText = showText;
           insertText += '<span class="hide">' + hideText + '</span>';
            insertText += '<span class="omit">…</span>';
-            insertText += '<a href="" class="more" style="color: #8c8c8c">あらすじを見る</a>';
+            insertText += '<a href="" class="more" style="color: #8c8c8c">あらすじを開く</a>';
             $(this).html(insertText);
        };
   });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,25 +50,27 @@ $(document).on('turbolinks:load',function(){
 
   // $("#get-novel-info-button").click(function(){
   $("#modal-novel-url").change(function(){
-      $.ajax({
-          url: "get_novel_info",
-          type: "GET",
-          data: { url : $("#modal-novel-url").val()
-                  },
-          dataType: "html",
-          success: function(data) {
-              console.log('success');
-              console.log(data);
-              // app/views/matomes/scraping_novel.js.erb
-              //上記ファイルの中身を文字列"delimiter"で分ける
-              var split_datas = data.split("delimiter");
-              $("#modal-novel-title").val(split_datas[0]);
-              $("#modal-novel-description").val(split_datas[1]);
-          },
-          error: function(data) {
-              console.log('error');
-              alert("URLが不正、もしくはこのURLには対応していません。");
-          }
-      });
+      if ($("#modal-novel-url").val() != "" ) {
+        $.ajax({
+            url: "get_novel_info",
+            type: "GET",
+            data: { url : $("#modal-novel-url").val()
+                    },
+            dataType: "html",
+            success: function(data) {
+                console.log('success');
+                console.log(data);
+                // app/views/matomes/scraping_novel.js.erb
+                //上記ファイルの中身を文字列"delimiter"で分ける
+                var split_datas = data.split("delimiter");
+                $("#modal-novel-title").val(split_datas[0]);
+                $("#modal-novel-description").val(split_datas[1]);
+            },
+            error: function(data) {
+                console.log('error');
+                alert("URLが不正、もしくはこのURLには対応していません。");
+            }
+        });
+      }
   });
 });

--- a/app/controllers/matomes_controller.rb
+++ b/app/controllers/matomes_controller.rb
@@ -78,8 +78,15 @@ class MatomesController < ApplicationController
     api_response = Net::HTTP.get(URI.parse(request_url))
     novel_info = JSON.parse(api_response)
 
-    @novel_title = novel_info[1]["title"]
-    @novel_description = novel_info[1]["story"]
+    # 入力されたURLが対応したURLだった場合、allcount(取得小説数)が1となる
+    # そうじゃない場合はnullを入れて、javascriptの方でエラーを出す。TODO ここでのnullはundefinedになっているが、結果的に望む動作をしている。
+    if novel_info[0]["allcount"] == 1
+      @novel_title = novel_info[1]["title"]
+      @novel_description = novel_info[1]["story"]
+    else
+      @novel_title = null
+      @novel_description = null
+    end
 
 
     # TODO ハーメルンとかをMechanizeでスクレイピングする場合を入れる


### PR DESCRIPTION
URLに変なアドレスが入れられた時にタイトルとあらすじを取得しないように修正。

allcount(API取得数)が1の時のみ動くように改修。